### PR TITLE
feat: Add support for OpenEligibility taxonomy

### DIFF
--- a/src/test/java/uk/codery/demo/openreferrals/controller/ServiceControllerTest.java
+++ b/src/test/java/uk/codery/demo/openreferrals/controller/ServiceControllerTest.java
@@ -1,0 +1,46 @@
+package uk.codery.demo.openreferrals.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.codery.demo.openreferrals.model.Service;
+import uk.codery.demo.openreferrals.service.ServiceService;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@WebMvcTest(ServiceController.class)
+public class ServiceControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ServiceService serviceService;
+
+    @Test
+    public void whenGetServicesByTaxonomy_thenReturnJsonArray() throws Exception {
+        Service service = new Service();
+        service.setName("Test Service");
+        List<Service> services = Collections.singletonList(service);
+        String taxonomyName = "test-taxonomy";
+
+        given(serviceService.findByTaxonomyName(taxonomyName)).willReturn(services);
+
+        mvc.perform(get("/api/services/taxonomy/" + taxonomyName)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name", is(service.getName())));
+    }
+}

--- a/src/test/java/uk/codery/demo/openreferrals/controller/TaxonomyControllerTest.java
+++ b/src/test/java/uk/codery/demo/openreferrals/controller/TaxonomyControllerTest.java
@@ -1,0 +1,58 @@
+package uk.codery.demo.openreferrals.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.codery.demo.openreferrals.model.Taxonomy;
+import uk.codery.demo.openreferrals.service.TaxonomyService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@WebMvcTest(TaxonomyController.class)
+public class TaxonomyControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private TaxonomyService taxonomyService;
+
+    @Test
+    public void whenGetAllTaxonomies_thenReturnJsonArray() throws Exception {
+        Taxonomy taxonomy = new Taxonomy("1", "test");
+        List<Taxonomy> allTaxonomies = Arrays.asList(taxonomy);
+
+        given(taxonomyService.getAllTaxonomies()).willReturn(allTaxonomies);
+
+        mvc.perform(get("/taxonomies")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name", is(taxonomy.getName())));
+    }
+
+    @Test
+    public void whenPostTaxonomy_thenCreateTaxonomy() throws Exception {
+        Taxonomy taxonomy = new Taxonomy(null, "test");
+        given(taxonomyService.createTaxonomy(taxonomy)).willReturn(new Taxonomy("1", "test"));
+
+        mvc.perform(post("/taxonomies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"test\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is("1")))
+                .andExpect(jsonPath("$.name", is("test")));
+    }
+}

--- a/src/test/java/uk/codery/demo/openreferrals/service/ServiceServiceTest.java
+++ b/src/test/java/uk/codery/demo/openreferrals/service/ServiceServiceTest.java
@@ -1,0 +1,45 @@
+package uk.codery.demo.openreferrals.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.codery.demo.openreferrals.model.Service;
+import uk.codery.demo.openreferrals.repository.ServiceRepository;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceServiceTest {
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    private ServiceService serviceService;
+
+    @BeforeEach
+    public void setUp() {
+        serviceService = new ServiceService(serviceRepository);
+    }
+
+    @Test
+    public void whenFindByTaxonomyName_thenReturnServices() {
+        Service service = new Service();
+        service.setName("Test Service");
+        List<Service> expectedServices = Collections.singletonList(service);
+        String taxonomyName = "test-taxonomy";
+
+        given(serviceRepository.findByTaxonomyName(taxonomyName)).willReturn(expectedServices);
+
+        List<Service> actualServices = serviceService.findByTaxonomyName(taxonomyName);
+
+        assertThat(actualServices).isEqualTo(expectedServices);
+        verify(serviceRepository).findByTaxonomyName(taxonomyName);
+    }
+}

--- a/src/test/java/uk/codery/demo/openreferrals/service/TaxonomyServiceTest.java
+++ b/src/test/java/uk/codery/demo/openreferrals/service/TaxonomyServiceTest.java
@@ -1,0 +1,57 @@
+package uk.codery.demo.openreferrals.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.codery.demo.openreferrals.model.Taxonomy;
+import uk.codery.demo.openreferrals.repository.TaxonomyRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxonomyServiceTest {
+
+    @Mock
+    private TaxonomyRepository taxonomyRepository;
+
+    private TaxonomyService taxonomyService;
+
+    @BeforeEach
+    public void setUp() {
+        taxonomyService = new TaxonomyService(taxonomyRepository);
+    }
+
+    @Test
+    public void whenGetAllTaxonomies_thenReturnAllTaxonomies() {
+        Taxonomy taxonomy1 = new Taxonomy("1", "Food");
+        Taxonomy taxonomy2 = new Taxonomy("2", "Housing");
+        List<Taxonomy> expectedTaxonomies = Arrays.asList(taxonomy1, taxonomy2);
+
+        given(taxonomyRepository.findAll()).willReturn(expectedTaxonomies);
+
+        List<Taxonomy> actualTaxonomies = taxonomyService.getAllTaxonomies();
+
+        assertThat(actualTaxonomies).isEqualTo(expectedTaxonomies);
+        verify(taxonomyRepository).findAll();
+    }
+
+    @Test
+    public void whenCreateTaxonomy_thenTaxonomyIsSaved() {
+        Taxonomy taxonomyToSave = new Taxonomy(null, "Health");
+        Taxonomy savedTaxonomy = new Taxonomy("1", "Health");
+
+        given(taxonomyRepository.save(taxonomyToSave)).willReturn(savedTaxonomy);
+
+        Taxonomy result = taxonomyService.createTaxonomy(taxonomyToSave);
+
+        assertThat(result).isEqualTo(savedTaxonomy);
+        verify(taxonomyRepository).save(taxonomyToSave);
+    }
+}


### PR DESCRIPTION
This change introduces support for the OpenEligibility taxonomy, allowing services to be categorized using a standardized vocabulary.

Key changes include:
- A new `Taxonomy` model to represent taxonomy terms.
- A many-to-many relationship between the `Service` and `Taxonomy` models.
- A `TaxonomyRepository` for database operations.
- A `TaxonomyService` and `TaxonomyController` to manage and expose taxonomies through a REST API.
- An updated `ServiceController` with an endpoint to search for services by taxonomy name.
- Configuration for an embedded MongoDB for testing purposes.
- Added unit tests for the new functionality.